### PR TITLE
ET-44: Integrate SweetAlert2 for Event Deletion Confirmation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,9 +20,11 @@
         "@angular/platform-server": "^17.3.0",
         "@angular/router": "^17.3.0",
         "@angular/ssr": "^17.3.3",
+        "@sweetalert2/ngx-sweetalert2": "^12.4.0",
         "express": "^4.18.2",
         "ngx-toastr": "^19.0.0",
         "rxjs": "~7.8.0",
+        "sweetalert2": "^11.15.3",
         "tslib": "^2.3.0",
         "zone.js": "~0.14.3"
       },
@@ -4442,6 +4444,19 @@
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "dev": true
+    },
+    "node_modules/@sweetalert2/ngx-sweetalert2": {
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/@sweetalert2/ngx-sweetalert2/-/ngx-sweetalert2-12.4.0.tgz",
+      "integrity": "sha512-8ZufWS5GRTBt8fCMUHFwDX6Yftbfzfs6zdshcpzTXbTEpIBYYOXL/ODHcdEOpgh/7bPjwi0SzDYcdRtwnrZfIQ==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "@angular/core": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "sweetalert2": "^11.0.0"
+      }
     },
     "node_modules/@tufjs/canonical-json": {
       "version": "2.0.0",
@@ -11816,6 +11831,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sweetalert2": {
+      "version": "11.15.3",
+      "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-11.15.3.tgz",
+      "integrity": "sha512-+0imNg+XYL8tKgx8hM0xoiXX3KfgxHDmiDc8nTJFO89fQEEhJlkecSdyYOZ3IhVMcUmoNte4fTIwWiugwkPU6w==",
+      "license": "MIT",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/limonte"
       }
     },
     "node_modules/symbol-observable": {

--- a/package.json
+++ b/package.json
@@ -23,9 +23,11 @@
     "@angular/platform-server": "^17.3.0",
     "@angular/router": "^17.3.0",
     "@angular/ssr": "^17.3.3",
+    "@sweetalert2/ngx-sweetalert2": "^12.4.0",
     "express": "^4.18.2",
     "ngx-toastr": "^19.0.0",
     "rxjs": "~7.8.0",
+    "sweetalert2": "^11.15.3",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.3"
   },

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -17,9 +17,7 @@ import { MatDialog } from '@angular/material/dialog';
   standalone: true,
   imports: [
     CommonModule,
-    AddEventDialogComponent,
     ReactiveFormsModule,
-    ConfirmationDialogComponent
   ],
   templateUrl: './dashboard.component.html',
   styleUrls: ['./dashboard.component.css']

--- a/src/app/view-event-dialog/view-event-dialog.component.ts
+++ b/src/app/view-event-dialog/view-event-dialog.component.ts
@@ -5,6 +5,8 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { ToastrService } from 'ngx-toastr';
 import { EventService } from '@core/services/event.service';
+import { SweetAlert2Module } from '@sweetalert2/ngx-sweetalert2';
+import Swal from 'sweetalert2';
 
 @Component({
   selector: 'app-view-event-dialog',
@@ -14,7 +16,8 @@ import { EventService } from '@core/services/event.service';
     MatFormFieldModule,
     MatInputModule,
     FormsModule,
-    MatDialogModule
+    MatDialogModule,
+    SweetAlert2Module
   ],
   templateUrl: './view-event-dialog.component.html',
   styleUrls: ['./view-event-dialog.component.css']
@@ -42,22 +45,36 @@ export class ViewEventDialogComponent {
     this.error = null;
   }
 
-  deleteEvent() {
-    const confirmation = confirm('Are you sure you want to delete this event?');
-    if (confirmation) {
-      this.eventService.deleteEvent(this.data.event.id).subscribe({
-        next: () => {
-          this.toastr.success('Event deleted successfully', 'Success');
-          this.eventService.deleteEvent(this.data.event); // Call the deleteEvent method from DashboardComponent
-          this.dialogRef.close(null); // Close the dialog after deletion
-        },
-        error: (error) => {
-          const errorMessage = error.error?.message || 'Failed to delete event';
-          this.toastr.error(errorMessage, 'Error');
-        }
-      });
-    }
+  deleteEvent(): void {
+    Swal.fire({
+      title: 'Are you sure?',
+      text: 'You won\'t be able to revert this!',
+      icon: 'warning',
+      showCancelButton: true,
+      confirmButtonColor: '#d33',
+      cancelButtonColor: '#3085d6',
+      confirmButtonText: 'Yes, delete it!',
+      cancelButtonText: 'Cancel',
+    }).then((result) => {
+      if (result.isConfirmed) {
+        this.eventService.deleteEvent(this.data.event.id).subscribe({
+          next: () => {
+            this.eventService.deleteEvent(this.data.event); // Call the deleteEvent method from DashboardComponent
+            this.dialogRef.close(null); // Close the dialog after deletion
+          },
+          error: (error) => {
+            const errorMessage = error.error?.message || 'Failed to delete event';
+            this.toastr.error(errorMessage, 'Error');
+          }
+        });
+        // Perform delete action
+        console.log('Event deleted:', this.data.event);
+        this.dialogRef.close('deleted'); // Optionally close the parent dialog
+        Swal.fire('Deleted!', 'Your event has been deleted.', 'success');
+      }
+    });
   }
+
 
   saveEvent() {
     this.eventService.updateEvent(this.data.event.id, this.data.event).subscribe({


### PR DESCRIPTION
## Description
This pull request replaces the previous MatDialog confirmation dialog with SweetAlert2 for a more modern and visually appealing user experience. Now, when a user clicks the Delete button on the event edit dialog, a SweetAlert2 modal appears, asking for confirmation before proceeding with the deletion.

## Changes 
- [x] Added SweetAlert2 to the project for beautiful modals.
- [x] Updated the deleteEvent() method to trigger a SweetAlert2 confirmation dialog.
- [x] Displayed a success message after confirming the deletion.
- [x] Used SweetAlert2's warning, success, and cancel button features for better user interaction.

## Screenshots
<img width="547" alt="Screenshot 2024-12-28 at 9 40 06 AM" src="https://github.com/user-attachments/assets/62bc2906-f5dd-492f-b2f0-9f11d21720f4" />

<img width="539" alt="Screenshot 2024-12-28 at 9 40 14 AM" src="https://github.com/user-attachments/assets/2c1ddc03-6252-4c79-bf8f-ea91686bdc71" />
